### PR TITLE
Slight improvements to the benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,16 @@ name = "worker"
 path = "src/worker/main.rs"
 
 [features]
-default = ["heed", "rocksdb"]
+default = ["jemalloc"]
 rocksdb = ["dep:rocksdb"]
 heed = ["dep:heed"]
-
-# [target.'cfg(not(target_env = "msvc"))'.dependencies]
-# jemallocator = "0.3.2"
+jemalloc = ["jemallocator"]
 
 [dependencies]
 clap = { version = "4.4.10", features = ["derive"] }
 # bloodstone = { package = "sled", version = "1.0.0-alpha.121" }
 sled = { version = "0.34.7", features = ["compression"] }
-fjall = { version = "1.2.0" }
+fjall = { version = "2.0" }
 nanoid = "0.4.0"
 rand = "0.8.5"
 sysinfo = { version = "0.30.1", features = ["serde"] }
@@ -39,3 +37,7 @@ heed = { version = "0.20.0", optional = true }
 rocksdb = { version = "0.22.0", optional = true, default-features = false, features = [
   "lz4",
 ] }
+jemallocator = { version = "0.5.2", optional = true }
+
+[profile.release]
+debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,14 +111,21 @@ pub struct Args {
     #[arg(long, default_value_t = 1)]
     pub threads: u8,
 
-    #[arg(long)]
+    /// How many items to pre-load the database with before starting the workload
+    #[arg(long, default_value_t = 1000000)]
     pub items: u32,
 
-    #[arg(long)]
+    // FIXME: this isn't being respected
+    #[arg(long, default_value_t = 64)]
     pub key_size: u8,
 
-    #[arg(long)]
+    #[arg(long, default_value_t = 1024)]
     pub value_size: u32,
+
+    /// When set the values used are snippets of Shakespere works,
+    /// instead of random (uncompressible values)
+    #[arg(long, default_value_t = true)]
+    pub compressible_value: bool,
 
     /// Block size for LSM-trees
     #[arg(long, default_value_t = 4_096)]
@@ -133,8 +140,12 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub sled_flush: bool,
 
-    #[arg(long, default_value_t = 16_000_000)]
+    #[arg(long, default_value_t = 512_000_000)]
     pub cache_size: u32,
+
+    /// Memtable/write-buffer size where applicable
+    #[arg(long, default_value_t = 64_000_000)]
+    pub write_buffer_size: u32,
 
     #[arg(long, default_value = "log.jsonl")]
     pub out: String,
@@ -147,4 +158,14 @@ pub struct Args {
 
     #[arg(long, default_value_t = 1)]
     pub minutes: u16,
+
+    /// If set, use a random keyspace, where the hot keys (zipf distribution)
+    /// are distributed throughout the keyspace.
+    /// If not set, uses monotonically increasing keys, where the hot keys (zipf distribution)
+    /// are concentrated at the beginning of the keyspace.
+    #[arg(long, default_value_t = false)]
+    pub random: bool,
+
+    #[arg(long, default_value_t = 0.99)]
+    pub zipf_exponent: f64,
 }


### PR DESCRIPTION
* Add option to benchmark non-sequential workloads. This is probably the most significant change. Tbh. without this, it's arguably too nice/artificial as it concentrates the updates/reads on the front section of the pre-loaded data and inserts are sequentially at the end. Note that zipfian distribution still applies, but the keys are not concentrated at the beginning.
* Add configuration for the zipfian distribution exponent (same default).
* ~~Use nanoseconds for timings (otherwise, some things may get truncated to 0us)~~
* ~~Enable using jemalloc which was commented out. Jemalloc/mimalloc/.. is recommended anywhere that is serious about performance.~~
* ~~Enable debug symbols, just in case anyone wants to use a profiler~~
* Add read-amplification/total reads graphs
* ~~Set space amplification graph min to 0 instead of 1, as it could be < 1 after compression.~~
* Add the option to use compressible values (default true). This will generate compressible values using Shakespeare's works (from Project Gutenberg).
* Add option to set memtable/write-buffer size
* ~~Capture write_latency outside the match branches (similar to the read path)~~

I've been playing with a storage engine (closer to lmdb than to Fjall) for many years in a private repo, but seeing Fjall earlier this year tempted me to try and make it public (eventually). So I thought I'd contribute to Fjall's benchmark and try to make the entire ecosystem better.