### PR TITLE
Update benchmark code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2021"
 debug = false
 
 [features]
-default = ["jemalloc", "canopydb"]
+default = ["jemalloc"]
 heed = ["dep:heed"]
-canopydb = ["dep:canopydb"]
 jemalloc = ["dep:jemallocator"]
 localfjall = []
 mimalloc = ["dep:mimalloc"]
@@ -21,7 +20,7 @@ tcmalloc = ["dep:tcmalloc"]
 jemallocator = { version = "0.5.4", optional = true }
 
 [dependencies]
-canopydb = { version = "0.2.4", optional = true }
+canopydb = { version = "0.2.4" }
 chrono = "0.4.38"
 clap = { version = "4.4.10", features = ["derive"] }
 env_logger = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 debug = false
 
 [features]
-default = ["jemalloc"]
+default = ["jemalloc", "canopydb"]
 heed = ["dep:heed"]
 canopydb = ["dep:canopydb"]
 jemalloc = ["dep:jemallocator"]
@@ -21,14 +21,14 @@ tcmalloc = ["dep:tcmalloc"]
 jemallocator = { version = "0.5.4", optional = true }
 
 [dependencies]
-canopydb = { version = "0.2.1", optional = true }
+canopydb = { version = "0.2.4", optional = true }
 chrono = "0.4.38"
 clap = { version = "4.4.10", features = ["derive"] }
 env_logger = "0.10.1"
 fake = { version = "2.9.2", features = ["derive", "uuid"] }
 fjall = { version = "2.8" }
 fs_extra = "1.3.0"
-hdrhistogram = "7.5.4"
+sketches-ddsketch = "0.3.0"
 heed = { version = "0.20.5", optional = true }
 # local_fjall = { package = "fjall", path = "../fjall", optional = true }
 log = { version = "0.4.20", features = ["release_max_level_trace"] }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Benchmarking Rust storage engines:
 - fjall Δ ★ (https://github.com/fjall-rs/fjall)
 - redb Ω ★ (https://www.redb.org)
 - sled Ψ (https://sled.rs)
+- canopydb Ω (https://github.com/arthurprs/canopydb)
 
 ---
 
@@ -28,7 +29,8 @@ alias bench="cargo run -r --"
 bench run --backend fjall --seconds 60 --value-size 100 --data-dir=.data --workload random --out stats.jsonl
 bench run --backend redb --seconds 60 --value-size 100 --data-dir=.data --workload random --out stats2.jsonl
 bench run --backend sled --seconds 60 --value-size 100 --data-dir=.data --workload random --out stats3.jsonl
-bench report --out report.html stats.jsonl stats2.jsonl stats3.jsonl
+bench run --backend canopydb --seconds 60 --value-size 100 --data-dir=.data --workload random --out stats4.jsonl
+bench report --out report.html stats.jsonl stats2.jsonl stats3.jsonl stats4.jsonl
 open report.html
 ```
 

--- a/random.nu
+++ b/random.nu
@@ -1,17 +1,18 @@
 #!/bin/nu
 
-let prefix = "randomrw";
+let prefix = "rw-random";
 let data_dir = ".data";
 let seconds = 5 * 60;
-let cache_mib = 500 * 1_024 * 1_024;
+let cache = 500 * 1_024 * 1_024;
 let value_size = 200;
+let item_count = 1_000_000;
 
 alias bench = cargo run -r --
 
 for db in ["fjall", "heed"] {
     let out = $"($prefix)_($db).jsonl";
     print $out;
-    RUST_BACKTRACE=full RUST_LOG=warn bench run --seconds $seconds --out $out --workload random --value-size $value_size --backend $db --data-dir $data_dir --item-count 50000000 --cache-size $cache_mib
+    RUST_BACKTRACE=full RUST_LOG=warn bench run --write-random --read-random --seconds $seconds --out $out --workload read-write --value-size $value_size --backend $db --data-dir $data_dir --item-count $item_count --cache-size $cache
     sleep 500ms
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -66,13 +66,23 @@ pub struct RunOptions {
     #[arg(long, default_value_t = 1_000_000)]
     pub item_count: usize,
 
+    /// Number of threads to use. Not applicable to all workloads
+    #[arg(long, default_value_t = 1)]
+    pub threads: usize,
+
     #[arg(long)]
     pub value_size: u32,
 
-    // TODO: zipf exponent
-    /// Whether to use random or Zipfian read distribution
+    #[arg(long, default_value_t = 0.9)]
+    pub zipf_exponent: f64,
+
+    /// Whether to use random or monotonic keys. Not applicable to all workloads
     #[arg(long, default_value_t = false)]
-    pub random: bool,
+    pub write_random: bool,
+
+    /// Whether to use random or Zipfian read distribution. Not applicable to all workloads
+    #[arg(long, default_value_t = false)]
+    pub read_random: bool,
 
     #[arg(long, default_value_t = false)]
     pub warmup_cache: bool,
@@ -80,17 +90,8 @@ pub struct RunOptions {
     /// Compaction for LSM-trees
     #[arg(long, value_enum, default_value_t = LsmCompaction::Leveled)]
     pub lsm_compaction: LsmCompaction,
-    // #[arg(long, default_value_t = 1)]
-    // pub threads: u8,
-
-    // #[arg(long, default_value_t = 0)]
-    // pub items: u32,
-
     // #[arg(long)]
     // pub key_size: u8,
-
-    // #[arg(long)]
-    // pub value_size: u32,
 
     // /// Use KV-separation
     // #[arg(long, alias = "lsm_kv_sep", default_value_t = false)]
@@ -108,9 +109,6 @@ pub struct RunOptions {
     // /// This is hopefully a temporary workaround
     // #[arg(long, default_value_t = false)]
     // pub sled_flush: bool,
-
-    // #[arg(long, default_value_t = false)]
-    // pub fsync: bool,
 }
 
 #[derive(Parser, Clone, Debug, Serialize)]

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -31,7 +31,6 @@ pub enum Backend {
     #[cfg(feature = "sqlite")]
     Sqlite,
 
-    #[cfg(feature = "canopydb")]
     #[serde(rename = "canopydb")]
     Canopydb,
     //
@@ -66,7 +65,6 @@ impl std::fmt::Display for Backend {
                 #[cfg(feature = "rocksdb")]
                 Self::RocksDb => "rocksdb 0.22.0",
 
-                #[cfg(feature = "canopydb")]
                 Self::Canopydb => "canopydb 0.2.4",
                 // Self::Bloodstone => "sled 1.0.0-alpha.122",
                 // Self::Persy => "persy 1.5.0",

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -67,7 +67,7 @@ impl std::fmt::Display for Backend {
                 Self::RocksDb => "rocksdb 0.22.0",
 
                 #[cfg(feature = "canopydb")]
-                Self::Canopydb => "canopydb 0.2.1",
+                Self::Canopydb => "canopydb 0.2.4",
                 // Self::Bloodstone => "sled 1.0.0-alpha.122",
                 // Self::Persy => "persy 1.5.0",
             }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,7 +2,7 @@ mod backend;
 
 use crate::args::RunOptions;
 pub use backend::Backend;
-use hdrhistogram::Histogram;
+use sketches_ddsketch::DDSketch;
 use std::{
     ops::Bound,
     path::Path,
@@ -48,6 +48,10 @@ const TABLE: redb::TableDefinition<&[u8], &[u8]> = redb::TableDefinition::new("d
 #[derive(Clone)]
 pub struct DatabaseWrapper {
     pub inner: GenericDatabase,
+    /// Current size of the workload (key + value length) in bytes
+    /// To get an accurate value, updates should be distinguished from inserts
+    /// and deletes must know the size of the deleted value.
+    pub workload_real_bytes: Arc<AtomicU64>,
 
     pub write_ops: Arc<AtomicU64>,
     pub write_latency: Arc<AtomicU64>,
@@ -55,13 +59,17 @@ pub struct DatabaseWrapper {
 
     pub point_read_ops: Arc<AtomicU64>,
     pub point_read_latency: Arc<AtomicU64>,
+    /// Number of bytes read in point reads (key + value length)
+    pub point_read_bytes: Arc<AtomicU64>,
 
     pub range_ops: Arc<AtomicU64>,
     pub range_latency: Arc<AtomicU64>,
+    /// Number of bytes read in range reads (key + value length)
+    pub range_read_bytes: Arc<AtomicU64>,
 
-    pub write_latency_histogram: Arc<Mutex<Histogram<u64>>>,
-    pub point_read_latency_histogram: Arc<Mutex<Histogram<u64>>>,
-    pub range_latency_histogram: Arc<Mutex<Histogram<u64>>>,
+    pub write_latency_histogram: Arc<Mutex<DDSketch>>,
+    pub point_read_latency_histogram: Arc<Mutex<DDSketch>>,
+    pub range_latency_histogram: Arc<Mutex<DDSketch>>,
 }
 
 impl std::ops::Deref for DatabaseWrapper {
@@ -73,8 +81,11 @@ impl std::ops::Deref for DatabaseWrapper {
 }
 
 impl DatabaseWrapper {
-    fn report_scan(&self, start: Instant) {
+    fn report_scan(&self, total_bytes: u64, start: Instant) {
         let latency = start.elapsed().as_nanos() as u64;
+
+        self.range_read_bytes
+            .fetch_add(total_bytes, std::sync::atomic::Ordering::Relaxed);
 
         self.range_latency
             .fetch_add(latency, std::sync::atomic::Ordering::Relaxed);
@@ -85,17 +96,13 @@ impl DatabaseWrapper {
         self.range_latency_histogram
             .lock()
             .unwrap()
-            .record(latency / 10)
-            .inspect_err(|_| {
-                log::warn!("Scan latency value too large for histogram");
-            })
-            .ok();
+            .add(latency as f64);
     }
 
     pub fn range_first(&self, range: (Bound<&[u8]>, Bound<&[u8]>)) -> Option<(Vec<u8>, Vec<u8>)> {
         let start = Instant::now();
 
-        let v = match &self.inner {
+        let v: Option<(Vec<u8>, Vec<u8>)> = match &self.inner {
             GenericDatabase::Fjall { db, keyspace } => {
                 let read_tx = keyspace.read_tx();
                 let mut iter = read_tx.range::<&[u8], _>(db, range);
@@ -128,21 +135,81 @@ impl DatabaseWrapper {
                     .unwrap()
                     .map(|(k, v)| (k.to_vec(), v.to_vec()))
             }
-            _ => unimplemented!(),
+            #[cfg(feature = "sqlite")]
+            GenericDatabase::Sqlite(db) => {
+                let (stmt, params) = sqlite_range(range, false);
+                db.lock()
+                    .unwrap()
+                    .prepare_cached(&stmt)
+                    .unwrap()
+                    .query_map(rusqlite::params_from_iter(params), |row| {
+                        let k = row.get_ref(0).unwrap();
+                        let v = row.get_ref(1).unwrap();
+                        use rusqlite::types::ValueRef;
+                        if let (ValueRef::Blob(k), ValueRef::Blob(v)) = (k, v) {
+                            Ok((k.to_vec(), v.to_vec()))
+                        } else {
+                            unreachable!()
+                        }
+                    })
+                    .unwrap()
+                    .next()
+                    .transpose()
+                    .unwrap()
+            }
+            GenericDatabase::Redb(db) => {
+                let tx = db.begin_read().unwrap();
+                let tree = tx.open_table(TABLE).unwrap();
+                let mut iter = tree.range::<&[u8]>(range).unwrap();
+                iter.next()
+                    .transpose()
+                    .unwrap()
+                    .map(|(k, v)| (k.value().to_vec(), v.value().to_vec()))
+            }
+            GenericDatabase::Sled(db) => {
+                let mut iter = db.range::<&[u8], _>(range);
+
+                iter.next()
+                    .transpose()
+                    .unwrap()
+                    .map(|(k, v)| (k.to_vec(), v.to_vec()))
+            }
+            #[cfg(feature = "heed")]
+            GenericDatabase::Heed { db, env } => {
+                let tx = env.read_txn().unwrap();
+                let mut iter = db.range(&tx, &range).unwrap();
+
+                iter.next()
+                    .transpose()
+                    .unwrap()
+                    .map(|(k, v)| (k.to_vec(), v.to_vec()))
+            }
+            #[cfg(feature = "rocksdb")]
+            GenericDatabase::RocksDb(db) => rocksdb_range(range, false, db)
+                .next()
+                .map(|(k, v)| (k.into(), v.into())),
         };
 
-        self.report_scan(start);
+        self.report_scan(
+            v.as_ref().map(|(k, v)| k.len() + v.len()).unwrap_or(0) as u64,
+            start,
+        );
 
         v
     }
 
     pub fn prefix_len(&self, prefix: &[u8], rev: bool, take: usize) -> usize {
         let start = Instant::now();
+        let mut sum_bytes = 0;
 
         let v = match &self.inner {
             #[cfg(feature = "sqlite")]
             GenericDatabase::Sqlite(_db) => {
-                unimplemented!();
+                let upper_bound = get_upper_bound(prefix);
+                let upper_bound = upper_bound
+                    .as_ref()
+                    .map_or(Bound::Unbounded, |b| Bound::Excluded(b.as_slice()));
+                return self.range_len((Bound::Included(prefix), upper_bound), rev, take);
             }
 
             #[cfg(feature = "localfjall")]
@@ -151,9 +218,20 @@ impl DatabaseWrapper {
                 let iter = read_tx.prefix(db, prefix);
 
                 if rev {
-                    iter.rev().take(take).map(|kv| kv.unwrap()).count()
+                    iter.rev()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
                 } else {
-                    iter.take(take).count()
+                    iter.take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
                 }
             }
             GenericDatabase::Fjall { db, keyspace } => {
@@ -161,52 +239,48 @@ impl DatabaseWrapper {
                 let iter = read_tx.prefix(db, prefix);
 
                 if rev {
-                    iter.rev().take(take).map(|kv| kv.unwrap()).count()
+                    iter.rev()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
                 } else {
-                    iter.take(take).count()
+                    iter.take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
                 }
             }
             GenericDatabase::Sled(db) => {
                 let iter = db.scan_prefix(prefix);
 
                 if rev {
-                    iter.rev().take(take).map(|kv| kv.unwrap()).count()
-                } else {
-                    iter.take(take).map(|kv| kv.unwrap()).count()
-                }
-            }
-            GenericDatabase::Redb(db) => {
-                let tx = db.begin_read().unwrap();
-
-                let table = tx.open_table(TABLE).unwrap();
-
-                let upper_bound = get_upper_bound(prefix);
-                let iter = if let Some(upper_bound) = upper_bound {
-                    table.range(prefix..&upper_bound[..]).unwrap()
-                } else {
-                    table.range(prefix..).unwrap()
-                };
-
-                if rev {
                     iter.rev()
-                        .map(|x| {
-                            let (k, v) = x.unwrap();
-                            let k: Vec<u8> = k.value().into();
-                            let v: Vec<u8> = v.value().into();
-                            (k, v)
-                        })
                         .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
                         .count()
                 } else {
-                    iter.map(|x| {
-                        let (k, v) = x.unwrap();
-                        let k: Vec<u8> = k.value().into();
-                        let v: Vec<u8> = v.value().into();
-                        (k, v)
-                    })
-                    .take(take)
-                    .count()
+                    iter.take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
                 }
+            }
+            GenericDatabase::Redb(_) => {
+                let upper_bound = get_upper_bound(prefix);
+                let upper_bound = upper_bound
+                    .as_ref()
+                    .map_or(Bound::Unbounded, |b| Bound::Excluded(b.as_slice()));
+                return self.range_len((Bound::Included(prefix), upper_bound), rev, take);
             }
 
             #[cfg(feature = "heed")]
@@ -215,37 +289,30 @@ impl DatabaseWrapper {
 
                 if rev {
                     let iter = db.rev_prefix_iter(&tx, prefix).unwrap();
-
                     iter.take(take)
-                        .map(|kv| {
-                            let (k, v) = kv.unwrap();
-                            (k.to_vec(), v.to_vec())
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
                         })
                         .count()
                 } else {
                     let iter = db.prefix_iter(&tx, prefix).unwrap();
-
                     iter.take(take)
-                        .map(|kv| {
-                            let (k, v) = kv.unwrap();
-                            (k.to_vec(), v.to_vec())
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
                         })
                         .count()
                 }
             }
 
             #[cfg(feature = "rocksdb")]
-            GenericDatabase::RocksDb(db) => {
-                let mut iter = db.iterator(rocksdb::IteratorMode::Start);
-                iter.set_mode(rocksdb::IteratorMode::From(
-                    prefix,
-                    if rev {
-                        rocksdb::Direction::Reverse
-                    } else {
-                        rocksdb::Direction::Forward
-                    },
-                ));
-                iter.take(take).map(|kv| kv.unwrap()).count()
+            GenericDatabase::RocksDb(_) => {
+                let upper_bound = get_upper_bound(prefix);
+                let upper_bound = upper_bound
+                    .as_ref()
+                    .map_or(Bound::Unbounded, |b| Bound::Excluded(b.as_slice()));
+                return self.range_len((Bound::Included(prefix), upper_bound), rev, take);
             }
             #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
@@ -255,14 +322,209 @@ impl DatabaseWrapper {
                 let range = tree.prefix(&prefix).unwrap();
 
                 if rev {
-                    range.rev().take(take).map(|kv| kv.unwrap()).count()
+                    range
+                        .rev()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
                 } else {
-                    range.take(take).map(|kv| kv.unwrap()).count()
+                    range
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
                 }
             }
         };
 
-        self.report_scan(start);
+        self.report_scan(sum_bytes as u64, start);
+
+        v
+    }
+
+    pub fn range_len(&self, range: (Bound<&[u8]>, Bound<&[u8]>), rev: bool, take: usize) -> usize {
+        let start = Instant::now();
+        let mut sum_bytes = 0;
+
+        let v = match &self.inner {
+            #[cfg(feature = "sqlite")]
+            GenericDatabase::Sqlite(db) => {
+                let (stmt, params) = sqlite_range(range, rev);
+                db.lock()
+                    .unwrap()
+                    .prepare_cached(&stmt)
+                    .unwrap()
+                    .query_map(rusqlite::params_from_iter(params), |row| {
+                        let k = row.get_ref(0).unwrap();
+                        let v = row.get_ref(1).unwrap();
+                        use rusqlite::types::ValueRef;
+                        if let (ValueRef::Blob(k), ValueRef::Blob(v)) = (k, v) {
+                            sum_bytes += k.len() + v.len();
+                        } else {
+                            unreachable!()
+                        }
+                        Ok(())
+                    })
+                    .unwrap()
+                    .take(take)
+                    .count()
+            }
+
+            #[cfg(feature = "localfjall")]
+            GenericDatabase::LocalFjall { db, keyspace } => {
+                let read_tx = keyspace.read_tx();
+                let iter = read_tx.range::<&[u8], _>(db, range);
+
+                if rev {
+                    iter.rev()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                } else {
+                    iter.take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                }
+            }
+            GenericDatabase::Fjall { db, keyspace } => {
+                let read_tx = keyspace.read_tx();
+                let iter = read_tx.range::<&[u8], _>(db, range);
+
+                if rev {
+                    iter.rev()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                } else {
+                    iter.take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                }
+            }
+            GenericDatabase::Sled(db) => {
+                let iter = db.range::<&[u8], _>(range);
+
+                if rev {
+                    iter.rev()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                } else {
+                    iter.take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                }
+            }
+            GenericDatabase::Redb(db) => {
+                let tx = db.begin_read().unwrap();
+
+                let table = tx.open_table(TABLE).unwrap();
+
+                let iter = table.range::<&[u8]>(range).unwrap();
+
+                if rev {
+                    iter.rev()
+                        .map(|x| x.unwrap())
+                        .take(take)
+                        .map(|(k, v)| {
+                            sum_bytes += k.value().len() + v.value().len();
+                        })
+                        .count()
+                } else {
+                    iter.map(|x| x.unwrap())
+                        .take(take)
+                        .map(|(k, v)| {
+                            sum_bytes += k.value().len() + v.value().len();
+                        })
+                        .count()
+                }
+            }
+
+            #[cfg(feature = "heed")]
+            GenericDatabase::Heed { db, env } => {
+                let tx = env.read_txn().unwrap();
+
+                if rev {
+                    db.rev_range(&tx, &range)
+                        .unwrap()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                } else {
+                    db.range(&tx, &range)
+                        .unwrap()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                }
+            }
+
+            #[cfg(feature = "rocksdb")]
+            GenericDatabase::RocksDb(db) => rocksdb_range(range, rev, db)
+                .take(take)
+                .map(|(k, v)| {
+                    sum_bytes += k.len() + v.len();
+                })
+                .count(),
+
+            #[cfg(feature = "canopydb")]
+            GenericDatabase::Canopydb(db) => {
+                let tx = db.begin_read().unwrap();
+                let tree = tx.get_tree(b"default").unwrap().unwrap();
+
+                let range = tree.range::<&[u8]>(range).unwrap();
+
+                if rev {
+                    range
+                        .rev()
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                } else {
+                    range
+                        .take(take)
+                        .map(|kv| kv.unwrap())
+                        .map(|(k, v)| {
+                            sum_bytes += k.len() + v.len();
+                        })
+                        .count()
+                }
+            }
+        };
+
+        self.report_scan(sum_bytes as u64, start);
 
         v
     }
@@ -498,8 +760,9 @@ impl DatabaseWrapper {
                     conn.pragma_update(None, "synchronous", "NORMAL").unwrap();
                 }
 
+                // TODO: test WITHOUT ROWID to get a clustered index
                 conn.execute(
-                    "CREATE TABLE data (key BLOB NOT NULL UNIQUE, value BLOB NOT NULL)",
+                    "CREATE TABLE data (key BLOB NOT NULL UNIQUE, value BLOB NOT NULL) STRICT",
                     (),
                 )
                 .unwrap();
@@ -704,20 +967,23 @@ impl DatabaseWrapper {
 
         DatabaseWrapper {
             inner: db,
+            workload_real_bytes: Default::default(),
 
             write_ops: Default::default(),
             write_latency: Default::default(),
             written_bytes: Default::default(),
 
+            point_read_bytes: Default::default(),
             point_read_ops: Default::default(),
             point_read_latency: Default::default(),
 
+            range_read_bytes: Default::default(),
             range_ops: Default::default(),
             range_latency: Default::default(),
 
-            write_latency_histogram: Arc::new(Mutex::new(Histogram::new(5).unwrap())),
-            point_read_latency_histogram: Arc::new(Mutex::new(Histogram::new(5).unwrap())),
-            range_latency_histogram: Arc::new(Mutex::new(Histogram::new(5).unwrap())),
+            write_latency_histogram: Default::default(),
+            point_read_latency_histogram: Default::default(),
+            range_latency_histogram: Default::default(),
             /*
             delete_ops: Default::default(),
             deleted_bytes: Default::default(),
@@ -734,95 +1000,19 @@ impl DatabaseWrapper {
         len
     } */
 
-    pub fn first(&self) -> Option<(Vec<u8>, Vec<u8>)> {
-        let start = Instant::now();
-
-        let item = match &self.inner {
-            GenericDatabase::Fjall { db, .. } => db
-                .first_key_value()
-                .unwrap()
-                .map(|(k, v)| (k.to_vec(), v.to_vec())),
-
-            #[cfg(feature = "localfjall")]
-            GenericDatabase::LocalFjall { db, .. } => db
-                .first_key_value()
-                .unwrap()
-                .map(|(k, v)| (k.to_vec(), v.to_vec())),
-
-            GenericDatabase::Sled(db) => db.first().unwrap().map(|(k, v)| (k.to_vec(), v.to_vec())),
-            GenericDatabase::Redb(db) => {
-                use redb::ReadableTable;
-
-                let read_txn = db.begin_read().unwrap();
-                let table = read_txn.open_table(TABLE).unwrap();
-                table
-                    .first()
-                    .unwrap()
-                    .map(|(k, v)| (k.value().to_vec(), v.value().to_vec()))
-            }
-            _ => self.range_first((Bound::Unbounded, Bound::Unbounded)),
-        };
-
-        self.report_scan(start);
-
-        item
-    }
-
-    /// NOTE: Purposefully only returns the length to avoid heap allocation
-    pub fn last_len(&self) -> Option<usize> {
-        let start = Instant::now();
-
-        let item = match &self.inner {
-            GenericDatabase::Fjall { db, .. } => {
-                let item = db.last_key_value().unwrap();
-                item.map(|(_, v)| v.len())
-            }
-
-            #[cfg(feature = "localfjall")]
-            GenericDatabase::LocalFjall { db, .. } => {
-                let item = db.last_key_value().unwrap();
-                item.map(|(_, v)| v.len())
-            }
-
-            GenericDatabase::Sled(db) => {
-                let item = db.last().unwrap();
-                item.map(|(_, v)| v.len())
-            }
-
-            GenericDatabase::Redb(db) => {
-                use redb::ReadableTable;
-
-                let read_txn = db.begin_read().unwrap();
-                let table = read_txn.open_table(TABLE).unwrap();
-                table.last().unwrap().map(|(_, v)| v.value().len())
-            }
-
-            #[cfg(feature = "canopydb")]
-            GenericDatabase::Canopydb(db) => {
-                let tx = db.begin_read().unwrap();
-                let tree = tx.get_tree(b"default").unwrap().unwrap();
-
-                tree.iter()
-                    .unwrap()
-                    .next_back()
-                    .transpose()
-                    .unwrap()
-                    .map(|(_, v)| v.len())
-            }
-
-            _ => unimplemented!(),
-        };
-
-        self.report_scan(start);
-        item
-    }
-
     pub fn len(&self) -> usize {
         match &self.inner {
             GenericDatabase::Fjall { db, .. } => db.inner().len().unwrap(),
 
             #[cfg(feature = "localfjall")]
             GenericDatabase::LocalFjall { db, .. } => db.inner().len().unwrap(),
+
+            #[cfg(feature = "canopydb")]
+            GenericDatabase::Canopydb(db) => {
+                let tx = db.begin_read().unwrap();
+                let tree = tx.get_tree(b"default").unwrap().unwrap();
+                tree.len() as usize
+            }
 
             _ => unimplemented!(),
         }
@@ -843,11 +1033,7 @@ impl DatabaseWrapper {
             self.point_read_latency_histogram
                 .lock()
                 .unwrap()
-                .record(point_read_latency / 10)
-                .inspect_err(|_| {
-                    log::warn!("Point read latency value too large for histogram");
-                })
-                .ok();
+                .add(point_read_latency as f64);
         };
 
         let item = match &self.inner {
@@ -927,37 +1113,70 @@ impl DatabaseWrapper {
                 value.map(|x| x.to_vec())
             }
         };
+        self.point_read_bytes.fetch_add(
+            key.len() as u64 + item.as_ref().map_or(0, |v| v.len() as u64),
+            std::sync::atomic::Ordering::Relaxed,
+        );
 
         item
     }
 
+    /// Ingest a batch of items into the database.
+    /// Assumes that the keys provided are unique and are not in the database, for statistics purposes.
+    /// Some databases (e.g., Fjall) may not support ingesting items out of order.
     pub fn ingest(&self, items: impl Iterator<Item = (Vec<u8>, Vec<u8>)>) {
         let start = Instant::now();
+        let mut count = 0u64;
+        let mut last_start = start;
 
-        let mut count = 0;
-        let mut bytes_written = 0;
+        let mut on_bytes_written = |k: &[u8], v: &[u8]| {
+            count += 1;
+            let total_bytes = (k.len() + v.len()) as u64;
+            let now = Instant::now();
+            let elapsed = now.duration_since(last_start);
+            last_start = now;
+            self.write_latency.fetch_add(
+                elapsed.as_nanos() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            self.written_bytes
+                .fetch_add(total_bytes, std::sync::atomic::Ordering::Relaxed);
+            self.workload_real_bytes
+                .fetch_add(total_bytes, std::sync::atomic::Ordering::Relaxed);
+            self.write_ops
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        };
 
         match &self.inner {
             #[cfg(feature = "sqlite")]
-            GenericDatabase::Sqlite(_db) => {
-                unimplemented!();
+            GenericDatabase::Sqlite(db) => {
+                let db = db.lock().unwrap();
+                db.execute("BEGIN IMMEDIATE", []).unwrap();
+                let mut stmt = db
+                    .prepare_cached("INSERT INTO data (key, value) VALUES (?, ?)")
+                    .unwrap();
+
+                for (key, value) in items {
+                    stmt.execute(rusqlite::params![key, value]).unwrap();
+                    on_bytes_written(&key, &value);
+                }
+                db.execute("COMMIT", []).unwrap();
+
+                // NOTE: Durability is controlled by pragma in load()
             }
 
             #[cfg(feature = "rocksdb")]
             GenericDatabase::RocksDb(db) => {
                 for (key, value) in items {
                     db.put(&key, &value).unwrap();
-
-                    count += 1;
-                    bytes_written += key.len() + value.len();
+                    on_bytes_written(&key, &value);
                 }
                 db.flush_wal(true).unwrap();
             }
             GenericDatabase::Fjall { db, .. } => {
                 db.inner()
                     .ingest(items.map(|(k, v)| {
-                        count += 1;
-                        bytes_written += k.len() + v.len();
+                        on_bytes_written(&k, &v);
                         (k, v)
                     }))
                     .unwrap();
@@ -966,8 +1185,7 @@ impl DatabaseWrapper {
             GenericDatabase::LocalFjall { db, .. } => {
                 db.inner()
                     .ingest(items.map(|(k, v)| {
-                        count += 1;
-                        bytes_written += k.len() + v.len();
+                        on_bytes_written(key.len() + value.len());
                         (k, v)
                     }))
                     .unwrap();
@@ -975,9 +1193,7 @@ impl DatabaseWrapper {
             GenericDatabase::Sled(db) => {
                 for (key, value) in items {
                     db.insert(&key, &*value).unwrap();
-
-                    count += 1;
-                    bytes_written += key.len() + value.len();
+                    on_bytes_written(&key, &value);
                 }
                 db.flush().unwrap();
             }
@@ -988,9 +1204,7 @@ impl DatabaseWrapper {
 
                     for (key, value) in items {
                         table.insert(&*key, &*value).unwrap();
-
-                        count += 1;
-                        bytes_written += key.len() + value.len();
+                        on_bytes_written(&key, &value);
                     }
                 }
                 write_txn.commit().unwrap();
@@ -1002,9 +1216,7 @@ impl DatabaseWrapper {
                     for (key, value) in items {
                         db.put_with_flags(&mut write_txn, heed::PutFlags::APPEND, &key, &value)
                             .unwrap();
-
-                        count += 1;
-                        bytes_written += key.len() + value.len();
+                        on_bytes_written(&key, &value);
                     }
                 }
                 write_txn.commit().unwrap();
@@ -1017,30 +1229,17 @@ impl DatabaseWrapper {
 
                     for (key, value) in items {
                         tree.insert(&key, &value).unwrap();
-
-                        count += 1;
-                        bytes_written += key.len() + value.len();
+                        on_bytes_written(&key, &value);
                     }
                 }
                 write_txn.commit().unwrap();
             }
         }
 
-        self.write_latency.fetch_add(
-            start.elapsed().as_nanos() as u64,
-            std::sync::atomic::Ordering::Relaxed,
-        );
-
-        self.write_ops
-            .fetch_add(count, std::sync::atomic::Ordering::Relaxed);
-
-        self.written_bytes
-            .fetch_add(bytes_written as u64, std::sync::atomic::Ordering::Relaxed);
-
         log::info!("Ingested {count} initial items in {:?}", start.elapsed());
     }
 
-    pub fn insert(&self, key: &[u8], value: &[u8], durable: bool) {
+    pub fn insert(&self, key: &[u8], value: &[u8], durable: bool, increment_workload_size: bool) {
         let start = Instant::now();
 
         match &self.inner {
@@ -1055,6 +1254,7 @@ impl DatabaseWrapper {
             }
 
             GenericDatabase::Fjall { keyspace, db } => {
+                // TODO: add option to write through transactions
                 db.insert(key, value).unwrap();
 
                 keyspace
@@ -1107,6 +1307,7 @@ impl DatabaseWrapper {
             }
             #[cfg(feature = "rocksdb")]
             GenericDatabase::RocksDb(db) => {
+                // TODO: add option to write through transactions
                 db.put(key, value).unwrap();
                 db.flush_wal(durable).unwrap();
             }
@@ -1137,15 +1338,19 @@ impl DatabaseWrapper {
         self.write_latency_histogram
             .lock()
             .unwrap()
-            .record(written_latency / 10)
-            .inspect_err(|_| {
-                log::warn!("Write latency value too large for histogram");
-            })
-            .ok();
+            .add(written_latency as f64);
+
+        if increment_workload_size {
+            self.workload_real_bytes.fetch_add(
+                (key.len() + value.len()) as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
     }
 
-    // TODO:
-    pub fn remove_unique(&self, key: &[u8], durable: bool) {
+    // TODO: this should probably be a configurable option `use_remove_unique` and then all workloads use
+    // the plain remove function. This way workloads can test both kinds.
+    pub fn remove_unique(&self, key: &[u8], durable: bool, decrement_workload_size: Option<u64>) {
         match &self.inner {
             #[cfg(feature = "localfjall")]
             GenericDatabase::LocalFjall { keyspace, db } => {
@@ -1160,23 +1365,30 @@ impl DatabaseWrapper {
                         local_fjall::PersistMode::Buffer
                     })
                     .unwrap();
+                if let Some(decrement_workload_size) = decrement_workload_size {
+                    self.workload_real_bytes.fetch_sub(
+                        decrement_workload_size,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                }
             }
             _ => {
-                self.remove(key, durable);
+                self.remove(key, durable, decrement_workload_size);
             }
         }
     }
 
-    pub fn remove(&self, key: &[u8], durable: bool) {
+    pub fn remove(&self, key: &[u8], durable: bool, decrement_workload_size: Option<u64>) {
         let _start = Instant::now();
 
         match &self.inner {
             #[cfg(feature = "sqlite")]
-            GenericDatabase::Sqlite(db) => {
+            GenericDatabase::Sqlite(_db) => {
                 unimplemented!()
             }
 
             GenericDatabase::Fjall { keyspace, db } => {
+                // TODO: add option to remove through transactions
                 db.remove(key).unwrap();
 
                 keyspace
@@ -1229,6 +1441,7 @@ impl DatabaseWrapper {
             }
             #[cfg(feature = "rocksdb")]
             GenericDatabase::RocksDb(db) => {
+                // TODO: add option to write through transactions
                 db.delete(key).unwrap();
                 db.flush_wal(durable).unwrap();
             }
@@ -1239,8 +1452,15 @@ impl DatabaseWrapper {
                     let mut tree = write_txn.get_tree(b"default").unwrap().unwrap();
                     tree.delete(key).unwrap();
                 }
-                write_txn.commit().unwrap();
+                write_txn.commit_with(durable).unwrap();
             }
+        }
+
+        if let Some(decrement_workload_size) = decrement_workload_size {
+            self.workload_real_bytes.fetch_sub(
+                decrement_workload_size,
+                std::sync::atomic::Ordering::Relaxed,
+            );
         }
 
         // TODO: latency
@@ -1263,9 +1483,101 @@ impl DatabaseWrapper {
     }
 }
 
+#[cfg(feature = "rocksdb")]
+fn rocksdb_range<'a>(
+    range: (Bound<&'a [u8]>, Bound<&'a [u8]>),
+    rev: bool,
+    db: &'a rocksdb::OptimisticTransactionDB,
+) -> impl Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a {
+    let (start, end) = if rev {
+        (range.1, range.0)
+    } else {
+        (range.0, range.1)
+    };
+    let it_mode = match start {
+        Bound::Included(x) | Bound::Excluded(x) => rocksdb::IteratorMode::From(
+            x,
+            if rev {
+                rocksdb::Direction::Reverse
+            } else {
+                rocksdb::Direction::Forward
+            },
+        ),
+        Bound::Unbounded if rev => rocksdb::IteratorMode::End,
+        Bound::Unbounded => rocksdb::IteratorMode::Start,
+    };
+    db.iterator(it_mode)
+        .map(|kv| kv.unwrap())
+        .enumerate()
+        .filter(move |(i, (k, _v))| {
+            if *i != 0 {
+                return true;
+            }
+            // skip the first element if it's an excluded start
+            if let Bound::Excluded(x) = start {
+                if rev {
+                    &k[..] < x
+                } else {
+                    &k[..] > x
+                }
+            } else {
+                true
+            }
+        })
+        .take_while(move |(_, (k, _v))| match end {
+            Bound::Included(x) => {
+                if rev {
+                    &k[..] >= x
+                } else {
+                    &k[..] <= x
+                }
+            }
+            Bound::Excluded(x) => {
+                if rev {
+                    &k[..] > x
+                } else {
+                    &k[..] < x
+                }
+            }
+            Bound::Unbounded => true,
+        })
+        .map(|(_, (k, v))| (k, v))
+}
+
+#[cfg(feature = "sqlite")]
+fn sqlite_range<'a>(
+    range: (Bound<&'a [u8]>, Bound<&'a [u8]>),
+    rev: bool,
+) -> (String, Vec<&'a [u8]>) {
+    let where_clause: &str = match range {
+        (Bound::Included(_), Bound::Included(_)) => "WHERE key >= ?1 AND key <= ?2",
+        (Bound::Included(_), Bound::Excluded(_)) => "WHERE key >= ?1 AND key < ?2",
+        (Bound::Excluded(_), Bound::Included(_)) => "WHERE key > ?1 AND key <= ?2",
+        (Bound::Excluded(_), Bound::Excluded(_)) => "WHERE key > ?1 AND key < ?2",
+        (Bound::Unbounded, Bound::Included(_)) => "WHERE key <= ?1",
+        (Bound::Included(_), Bound::Unbounded) => "WHERE key >= ?1",
+        (Bound::Unbounded, Bound::Excluded(_)) => "WHERE key < ?1",
+        (Bound::Excluded(_), Bound::Unbounded) => "WHERE key > ?1",
+        (Bound::Unbounded, Bound::Unbounded) => "",
+    };
+    let stmt = if rev {
+        format!("SELECT key, value FROM data {where_clause} ORDER BY key DESC")
+    } else {
+        format!("SELECT key, value FROM data {where_clause} ORDER BY key")
+    };
+    let mut params = Vec::with_capacity(2);
+    if let Bound::Included(x) | Bound::Excluded(x) = range.0 {
+        params.push(x);
+    }
+    if let Bound::Included(x) | Bound::Excluded(x) = range.1 {
+        params.push(x);
+    }
+    (stmt, params)
+}
+
 /// Returns the upper bound of a prefix, or None
 /// if the range must be scanned from prefix until the end.
-pub fn get_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
+fn get_upper_bound(prefix: &[u8]) -> Option<Vec<u8>> {
     let mut end = prefix.to_vec();
     let len = end.len();
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -806,6 +806,9 @@ impl DatabaseWrapper {
                 let env = unsafe {
                     heed::EnvOpenOptions::new()
                         .map_size(128_000_000_000)
+                        // TODO: make LMDB NO_SYNC a separate option
+                        // as this isn't equivalent to fsync=false for the
+                        // other databases which treat it like "no sync commit"
                         .flags(if args.fsync {
                             EnvFlags::NO_READ_AHEAD
                         } else {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -27,7 +27,6 @@ pub enum GenericDatabase {
 
     Redb(Arc<redb::Database>),
 
-    #[cfg(feature = "canopydb")]
     Canopydb(Arc<canopydb::Database>),
 
     #[cfg(feature = "heed")]
@@ -123,7 +122,6 @@ impl DatabaseWrapper {
                     .unwrap()
                     .map(|(k, v)| (k.to_vec(), v.to_vec()))
             }
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let tx = db.begin_read().unwrap();
                 let tree = tx.get_tree(b"default").unwrap().unwrap();
@@ -314,7 +312,6 @@ impl DatabaseWrapper {
                     .map_or(Bound::Unbounded, |b| Bound::Excluded(b.as_slice()));
                 return self.range_len((Bound::Included(prefix), upper_bound), rev, take);
             }
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let tx = db.begin_read().unwrap();
                 let tree = tx.get_tree(b"default").unwrap().unwrap();
@@ -496,7 +493,6 @@ impl DatabaseWrapper {
                 })
                 .count(),
 
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let tx = db.begin_read().unwrap();
                 let tree = tx.get_tree(b"default").unwrap().unwrap();
@@ -560,7 +556,6 @@ impl DatabaseWrapper {
                 let tx = env.read_txn().unwrap();
                 db.stat(&tx).unwrap().depth as usize
             }
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let tx = db.begin_read().unwrap();
                 let tree = tx.get_tree(b"default").unwrap().unwrap();
@@ -947,7 +942,6 @@ impl DatabaseWrapper {
                 GenericDatabase::LocalFjall { keyspace, db }
             }
 
-            #[cfg(feature = "canopydb")]
             Backend::Canopydb => {
                 std::fs::create_dir_all(&path).unwrap();
 
@@ -1007,7 +1001,6 @@ impl DatabaseWrapper {
             #[cfg(feature = "localfjall")]
             GenericDatabase::LocalFjall { db, .. } => db.inner().len().unwrap(),
 
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let tx = db.begin_read().unwrap();
                 let tree = tx.get_tree(b"default").unwrap().unwrap();
@@ -1103,7 +1096,6 @@ impl DatabaseWrapper {
                 report_latency();
                 value.map(ToOwned::to_owned)
             }
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let tx = db.begin_read().unwrap();
                 let tree = tx.get_tree(b"default").unwrap().unwrap();
@@ -1221,7 +1213,6 @@ impl DatabaseWrapper {
                 }
                 write_txn.commit().unwrap();
             }
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let write_txn = db.begin_write().unwrap();
                 {
@@ -1311,7 +1302,6 @@ impl DatabaseWrapper {
                 db.put(key, value).unwrap();
                 db.flush_wal(durable).unwrap();
             }
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let write_txn = db.begin_write().unwrap();
                 {
@@ -1445,7 +1435,6 @@ impl DatabaseWrapper {
                 db.delete(key).unwrap();
                 db.flush_wal(durable).unwrap();
             }
-            #[cfg(feature = "canopydb")]
             GenericDatabase::Canopydb(db) => {
                 let write_txn = db.begin_write().unwrap();
                 {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,7 +1,7 @@
 use crate::{args::RunOptions, db::DatabaseWrapper, unix_timestamp};
 use std::{
     fs::File,
-    io::Write,
+    io::{BufWriter, Write},
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -13,7 +13,7 @@ use std::{
 use sysinfo::{Pid, ProcessRefreshKind, System};
 
 pub fn start_monitor(
-    mut file_writer: File,
+    file_writer: File,
     data_dir: PathBuf,
     mut sys: System,
     db: DatabaseWrapper,
@@ -23,6 +23,7 @@ pub fn start_monitor(
     let mut prev_write_ops = 0;
     let mut prev_point_read_ops = 0;
     let mut prev_range_ops = 0;
+    let mut file_writer = BufWriter::new(file_writer);
 
     log::debug!("Starting monitor");
 
@@ -36,7 +37,7 @@ pub fn start_monitor(
         .spawn(move || {
             // "How often does this run per second?"
             let frequency =
-                (Duration::from_secs(1).as_millis() as f32) / (args.granularity_ms as f32);
+                (Duration::from_secs(1).as_millis() as f64) / (args.granularity_ms as f64);
 
             let mut potential_write_ops = 0;
             let mut potential_point_read_ops = 0;
@@ -53,9 +54,9 @@ pub fn start_monitor(
 
                 let time_ms = start_instant.elapsed().as_millis();
                 let cpu = child.cpu_usage();
-                let mem = (child.memory() as f32 / 1_024.0) as u64;
+                let mem_kib = (child.memory() as f64 / 1_024.0) as u64;
 
-                if mem >= 16 * 1_024 * 1_024 {
+                if mem_kib >= 16 * 1_024 * 1_024 {
                     log::error!("OOM KILLER!! Exceeded 16GB of memory");
                     std::process::exit(666);
                 }
@@ -68,10 +69,17 @@ pub fn start_monitor(
                     std::process::exit(0);
                 }
 
+                let workload_real_bytes = db.workload_real_bytes.load(Ordering::Relaxed);
                 let disk = child.disk_usage();
 
+                let read_user_bytes = db.range_read_bytes.load(Ordering::Relaxed)
+                    + db.point_read_bytes.load(Ordering::Relaxed);
                 let written_user_bytes = db.written_bytes.load(Ordering::Relaxed);
-                let write_amp = (disk.total_written_bytes as f64) / (written_user_bytes as f64);
+                let write_amp = if written_user_bytes == 0 {
+                    0.0
+                } else {
+                    (disk.total_written_bytes as f64) / (written_user_bytes as f64)
+                };
 
                 let disk_writes_kib = disk.total_written_bytes / 1_024;
                 let disk_reads_kib = disk.total_read_bytes / 1_024;
@@ -87,11 +95,11 @@ pub fn start_monitor(
                 let write_ops_since = write_ops - prev_write_ops;
                 let avg_write_latency = accumulated_write_latency / write_ops_since.max(1);
                 let write_rate_per_second = if avg_write_latency > 0 {
-                    Duration::from_secs(1).as_nanos() / avg_write_latency as u128
+                    Duration::from_secs(1).as_nanos() as u64 / avg_write_latency
                 } else {
                     0
                 };
-                potential_write_ops += (write_rate_per_second as f32 / frequency) as u64;
+                potential_write_ops += (write_rate_per_second as f64 / frequency) as u64;
 
                 let accumulated_point_read_latency = db
                     .point_read_latency
@@ -99,11 +107,10 @@ pub fn start_monitor(
                 let point_read_ops_since = point_read_ops - prev_point_read_ops;
                 let avg_point_read_latency =
                     accumulated_point_read_latency / point_read_ops_since.max(1);
-                let point_read_rate_per_second = Duration::from_secs(1)
-                    .as_nanos()
-                    .checked_div(avg_point_read_latency as u128)
+                let point_read_rate_per_second = (Duration::from_secs(1).as_nanos() as u64)
+                    .checked_div(avg_point_read_latency)
                     .unwrap_or_default();
-                potential_point_read_ops += (point_read_rate_per_second as f32 / frequency) as u64;
+                potential_point_read_ops += (point_read_rate_per_second as f64 / frequency) as u64;
 
                 let accumulated_range_latency = db
                     .range_latency
@@ -111,18 +118,22 @@ pub fn start_monitor(
                 let range_ops_since = range_ops - prev_range_ops;
                 let avg_range_latency = accumulated_range_latency / range_ops_since.max(1);
                 let range_rate_per_second = if avg_range_latency > 0 {
-                    Duration::from_secs(1).as_nanos() / avg_range_latency as u128
+                    Duration::from_secs(1).as_nanos() as u64 / avg_range_latency
                 } else {
                     0
                 };
-                potential_range_ops += (range_rate_per_second as f32 / frequency) as u64;
+                potential_range_ops += (range_rate_per_second as f64 / frequency) as u64;
 
-                // TODO: space amp is broken for update workloads because written_user_bytes increases
-                // TODO: but an update doesn't actually add more data to the database (logically)
-                let space_amp = if disk_space_kib == 0 {
+                let space_amp = if workload_real_bytes == 0 {
                     0.0
                 } else {
-                    ((disk_space_kib * 1_024) as f64) / (written_user_bytes as f64)
+                    ((disk_space_kib * 1_024) as f64) / (workload_real_bytes as f64)
+                };
+
+                let read_amp = if read_user_bytes == 0 {
+                    0.0
+                } else {
+                    (disk.total_read_bytes as f64) / (read_user_bytes as f64)
                 };
 
                 let l0_avg_segment_lifetime_ms = {
@@ -139,7 +150,7 @@ pub fn start_monitor(
                 let json = serde_json::json!([
                     time_ms,
                     format!("{:.2}", cpu).parse::<f64>().unwrap(),
-                    mem,
+                    mem_kib,
                     //
                     disk_space_kib,
                     disk_writes_kib,
@@ -186,7 +197,9 @@ pub fn start_monitor(
                     format!("{:.2}", space_amp)
                         .parse::<f64>()
                         .unwrap_or_default(),
-                    1.0, // TODO: read amp
+                    format!("{:.2}", read_amp)
+                        .parse::<f64>()
+                        .unwrap_or_default(),
                 ]);
 
                 writeln!(&mut file_writer, "{json}").unwrap();
@@ -205,7 +218,6 @@ pub fn start_monitor(
             writeln!(&mut file_writer, "{}", serde_json::json!({ "fin": true })).unwrap();
 
             {
-                // NOTE: We store values in deci-nano-seconds
                 let histogram = db.write_latency_histogram.lock().unwrap();
                 writeln!(
                     &mut file_writer,
@@ -214,18 +226,17 @@ pub fn start_monitor(
                         "histogram": true,
                         "type": "write",
                         "unit": "ns",
-                        "mean": (histogram.mean() * 10.0) as u64,
-                        "p50": histogram.value_at_quantile(0.50) * 10,
-                        "p90": histogram.value_at_quantile(0.90) * 10,
-                        "p95": histogram.value_at_quantile(0.95) * 10,
-                        "p99": histogram.value_at_quantile(0.99) * 10,
+                        "mean": histogram.sum().unwrap_or(0.0) / histogram.count() as f64,
+                        "p50": histogram.quantile(0.50).unwrap().unwrap_or_default(),
+                        "p90": histogram.quantile(0.90).unwrap().unwrap_or_default(),
+                        "p95": histogram.quantile(0.95).unwrap().unwrap_or_default(),
+                        "p99": histogram.quantile(0.99).unwrap().unwrap_or_default(),
                     })
                 )
                 .unwrap();
             }
 
             {
-                // NOTE: We store values in deci-nano-seconds
                 let histogram = db.point_read_latency_histogram.lock().unwrap();
                 writeln!(
                     &mut file_writer,
@@ -234,18 +245,17 @@ pub fn start_monitor(
                         "histogram": true,
                         "type": "point_read",
                         "unit": "ns",
-                        "mean": (histogram.mean() * 10.0) as u64,
-                        "p50": histogram.value_at_quantile(0.50) * 10,
-                        "p90": histogram.value_at_quantile(0.90) * 10,
-                        "p95": histogram.value_at_quantile(0.95) * 10,
-                        "p99": histogram.value_at_quantile(0.99) * 10,
+                        "mean": histogram.sum().unwrap_or(0.0) / histogram.count() as f64,
+                        "p50": histogram.quantile(0.50).unwrap().unwrap_or_default(),
+                        "p90": histogram.quantile(0.90).unwrap().unwrap_or_default(),
+                        "p95": histogram.quantile(0.95).unwrap().unwrap_or_default(),
+                        "p99": histogram.quantile(0.99).unwrap().unwrap_or_default(),
                     })
                 )
                 .unwrap();
             }
 
             {
-                // NOTE: We store values in deci-nano-seconds
                 let histogram = db.range_latency_histogram.lock().unwrap();
                 writeln!(
                     &mut file_writer,
@@ -254,17 +264,17 @@ pub fn start_monitor(
                         "histogram": true,
                         "type": "range_read",
                         "unit": "ns",
-                        "mean": (histogram.mean() * 10.0) as u64,
-                        "p50": histogram.value_at_quantile(0.50) * 10,
-                        "p90": histogram.value_at_quantile(0.90) * 10,
-                        "p95": histogram.value_at_quantile(0.95) * 10,
-                        "p99": histogram.value_at_quantile(0.99) * 10,
+                        "mean": histogram.sum().unwrap_or(0.0) / histogram.count() as f64,
+                        "p50": histogram.quantile(0.50).unwrap().unwrap_or_default(),
+                        "p90": histogram.quantile(0.90).unwrap().unwrap_or_default(),
+                        "p95": histogram.quantile(0.95).unwrap().unwrap_or_default(),
+                        "p99": histogram.quantile(0.99).unwrap().unwrap_or_default(),
                     })
                 )
                 .unwrap();
             }
 
-            file_writer.sync_all().unwrap();
+            file_writer.into_inner().unwrap().sync_all().unwrap();
 
             std::process::exit(0);
         })

--- a/src/workload/feed.rs
+++ b/src/workload/feed.rs
@@ -50,28 +50,28 @@ pub struct FeedPost {
 }
 
 const VIRTUAL_USERS: usize = 10_000;
-const INITIAL_POSTS_PER_USER: usize = 1_000;
 
 pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBool>) {
     log::debug!("Pre-writing items");
 
-    let users = (0..VIRTUAL_USERS).map(|user_idx| {
-        let user_id = format!("u{user_idx:0>7}");
-        let user_profile_key = format!("{user_id}#p");
-
-        let profile: UserProfile = Faker.fake();
-        let profile = rmp_serde::to_vec(&profile).unwrap();
-
-        (user_profile_key.as_bytes().to_vec(), profile)
-    });
-
     let mut rng = rand::thread_rng();
     let mut buf = vec![0; args.value_size as usize];
+    let feed_limit = 10;
+    let initial_posts_per_user = (args.item_count / VIRTUAL_USERS).max(feed_limit);
 
     let iter = (0..VIRTUAL_USERS)
-        .flat_map(|x| (0..INITIAL_POSTS_PER_USER).clone().map(move |y| (x, y)))
-        .map(|(user_idx, _post_idx)| {
+        .flat_map(|x| (0..=initial_posts_per_user).clone().map(move |y| (x, y)))
+        .map(|(user_idx, post_idx)| {
             let user_id = format!("u{user_idx:0>7}");
+
+            // Insert profile last to keep insertion order consistent
+            if post_idx == initial_posts_per_user {
+                let user_profile_key: String = format!("{user_id}#p");
+
+                let profile: UserProfile = Faker.fake();
+                let profile = rmp_serde::to_vec(&profile).unwrap();
+                return (user_profile_key.as_bytes().to_vec(), profile);
+            }
 
             // Insert post
             let post_id = scru128::new_string();
@@ -80,12 +80,11 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
             rng.fill_bytes(&mut buf);
 
             (post_key.as_bytes().to_vec(), buf.clone())
-        })
-        .chain(users);
+        });
 
     db.ingest(iter);
 
-    let threads = (0..1)
+    let threads = (0..args.threads)
         .map(|_thread_no| {
             let args = args.clone();
             let db = db.clone();
@@ -93,13 +92,13 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
             std::thread::spawn(move || {
                 let mut rng = rand::thread_rng();
                 let mut buf = vec![0; args.value_size as usize];
+                let zipf = ZipfDistribution::new(VIRTUAL_USERS, args.zipf_exponent).unwrap();
 
                 for _loop_idx in 0.. {
                     let choice: f32 = rng.gen_range(0.0..1.0);
 
                     // Which user?
-                    let zipf = ZipfDistribution::new((VIRTUAL_USERS - 1) as usize, 1.0).unwrap();
-                    let idx = zipf.sample(&mut rng);
+                    let idx = zipf.sample(&mut rng) - 1;
                     let user_id = format!("u{idx:0>7}");
 
                     if choice > 0.9 {
@@ -109,19 +108,18 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
 
                         rng.fill_bytes(&mut buf);
 
-                        db.insert(post_key.as_bytes(), &buf, args.fsync);
+                        db.insert(post_key.as_bytes(), &buf, args.fsync, true);
                     } else {
                         // Get profile
                         let user_profile_key = format!("{user_id}#p");
                         db.get(user_profile_key.as_bytes()).unwrap();
 
-                        // // + latest 10 posts
+                        // + latest initial_posts_per_user posts
                         let feed_prefix = format!("{user_id}#f#");
-                        let limit = 10;
 
                         assert_eq!(
-                            limit,
-                            db.prefix_len(feed_prefix.as_bytes(), true, limit),
+                            feed_limit,
+                            db.prefix_len(feed_prefix.as_bytes(), true, feed_limit),
                             "{feed_prefix} failed"
                         );
                     }

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -1,11 +1,12 @@
 mod feed;
 mod monotonic;
 mod monotonic_fixed;
+mod read_write;
 mod ycsb;
 
 use crate::{args::RunOptions, db::DatabaseWrapper};
 use clap::ValueEnum;
-use rand::{Rng, RngCore};
+use rand::{prelude::Distribution, Rng, RngCore};
 use serde::Serialize;
 use std::{
     hash::Hasher,
@@ -15,6 +16,7 @@ use std::{
     },
     time::Duration,
 };
+use zipf::ZipfDistribution;
 
 fn start_killer(sec: u16, signal: Arc<AtomicBool>) {
     log::debug!("Started killer");
@@ -55,6 +57,8 @@ pub enum Workload {
     /// 10% a random virtual user will create a new post
     Feed,
 
+    /// Writes data and then reads and update it for a fixed amount of time
+    /// The write and read distribution can be configured.
     FixedUpdate,
 
     // /// Writes time series data, then point reads it zipfian-ly
@@ -70,15 +74,24 @@ pub enum Workload {
     /// Time series (increasing integer key, small value), read latest 1'000 data points
     TimeseriesLatest,
 
-    /// Uses siphash as key which makes writes very random; write-only
+    /// Random writes; write-only
     RandomWrite,
 
-    /// Uses siphash as key which makes writes very random, reads
-    /// a pre-selected subset of keys randomly
-    Random,
+    /// Read Write workload with 2 independent read and writer threads running in parallel.
+    /// The write and read distribution can be configured.
+    ReadWriteIndependent,
 
-    /// Queue using a single producer and single consumer
+    /// Read Write workload with multiple actor threads.
+    /// The configured number of threads are spawned and enter a loop with equal chances of performing a read or write.
+    /// The write and read distribution can be configured.
+    ReadWrite,
+
+    /// Queue workload with 2 independent producer and consumer threads running in parallel.
+    /// The producer will throttle if the consumer is not consuming fast enough.
     Queue,
+
+    /// Queue workload with 2 independent producer and consumer threads running in parallel.
+    QueueIndependent,
 }
 
 pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<AtomicBool>) {
@@ -132,21 +145,32 @@ pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<A
         Workload::FixedUpdate => {
             let seconds = 30;
             let iterations = 100_000_000 / args.item_count;
+            let exponent = args.zipf_exponent;
 
             println!("Doing {iterations} iterations");
 
             let mut written_count = 0;
             let mut buf = vec![0; args.value_size as usize];
+            let random_key_distribution = args.write_random;
+            let key_mapper = move |k: u64| -> u64 {
+                if random_key_distribution {
+                    k
+                } else {
+                    hash_key(k)
+                }
+            };
+            let read_random = args.read_random;
 
             for _ in 0..iterations {
                 println!("Ingesting {} items", args.item_count);
-                let item_count = args.item_count as u128;
+                let item_count = args.item_count as u64;
 
                 let mut rng = rand::thread_rng();
 
                 let iter = (written_count..(written_count + item_count)).map(|x| {
                     rng.fill_bytes(&mut buf);
-                    (x.to_be_bytes().to_vec(), buf.to_vec())
+                    let x = key_mapper(x);
+                    ((x as u128).to_be_bytes().to_vec(), buf.to_vec())
                 });
 
                 db.ingest(iter);
@@ -162,21 +186,17 @@ pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<A
                     move || {
                         let mut rng = rand::thread_rng();
 
-                        for x in 0.. {
-                            #[allow(clippy::collapsible_if)]
-                            if x % 1_000 == 0 {
-                                if stopped.load(Ordering::Relaxed) {
-                                    return;
-                                }
-                            }
+                        while !stopped.load(Ordering::Relaxed) {
+                            let x = if read_random {
+                                rng.gen_range(0..written_count)
+                            } else {
+                                choose_zipf(&mut rng, exponent, written_count)
+                            };
 
-                            // TODO: support Zipfian reads
-                            let x = rng.gen_range(0..written_count);
-
-                            let key = x.to_be_bytes();
+                            let key = (x as u128).to_be_bytes();
                             let prev = db.get(&key).unwrap();
                             let prev = prev.into_iter().map(|x| !x).collect::<Vec<_>>();
-                            db.insert(&key, &prev, fsync);
+                            db.insert(&key, &prev, fsync, false);
                         }
                     }
                 });
@@ -197,7 +217,7 @@ pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<A
                 move || {
                     for x in 0u128.. {
                         let key = x.to_be_bytes();
-                        db.insert(&key, &key, fsync);
+                        db.insert(&key, &key, fsync, true);
                     }
                 }
             });
@@ -224,7 +244,7 @@ pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<A
                 move || {
                     for x in 0u128.. {
                         let key = x.to_be_bytes();
-                        db.insert(&key, &key, fsync);
+                        db.insert(&key, &key, fsync, true);
                         written_count.fetch_add(1, Ordering::Relaxed);
                     }
                 }
@@ -233,68 +253,78 @@ pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<A
             std::thread::spawn({
                 log::debug!("Starting reader");
                 let db = db.clone();
-                let written_count = written_count.clone();
 
                 move || loop {
-                    let max_key = written_count.load(Ordering::Relaxed).saturating_sub(1);
-
-                    // TODO: implement range read, not last
-                    if max_key > 1 {
-                        db.last_len().unwrap();
-                    }
+                    let written_count = written_count.load(Ordering::Relaxed);
+                    let last_key_bytes = (written_count as u128).to_be_bytes();
+                    let end_exclusive = std::ops::Bound::Excluded(&last_key_bytes[..]);
+                    let len = db.range_len((std::ops::Bound::Unbounded, end_exclusive), true, 1000);
+                    assert_eq!(len, written_count.min(1000) as usize);
                 }
             });
 
             start_killer(args.seconds, finish_signal);
         }
-        Workload::Queue => {
+        Workload::Queue | Workload::QueueIndependent => {
+            let with_backpressure = matches!(args.workload, Workload::Queue);
+            let mutex = Arc::new(std::sync::Mutex::new(()));
+            let condvar = Arc::new(std::sync::Condvar::new());
+            let pending_writes = Arc::new(AtomicU64::new(0));
+            let max_pending = 1_000;
+
             std::thread::spawn({
                 log::debug!("Starting writer");
                 let db = db.clone();
                 let mut buf = vec![0; args.value_size as usize];
+                let condvar = condvar.clone();
+                let pending_writes = pending_writes.clone();
+                let mutex = mutex.clone();
 
                 move || {
                     let mut rng = rand::thread_rng();
-
-                    for seqno in 0u128.. {
+                    // Note how we're starting at 1 instead of 0
+                    for seqno in 1u128.. {
                         rng.fill_bytes(&mut buf);
-                        db.insert(&seqno.to_be_bytes(), &buf, fsync);
+                        db.insert(&seqno.to_be_bytes(), &buf, fsync, true);
+                        if pending_writes.fetch_add(1, Ordering::Relaxed) >= max_pending
+                            && with_backpressure
+                        {
+                            // Wait for the consumer to consume one
+                            let _guard = condvar.wait(mutex.lock().unwrap()).unwrap();
+                        } else {
+                            // Notify the consumer that we wrote one
+                            condvar.notify_one();
+                        }
                     }
                 }
             });
 
-            let fsync = args.fsync;
+            let value_size = args.value_size;
+            let decrement_workload_size = Some((16 + value_size) as u64);
 
             std::thread::spawn({
                 log::debug!("Starting reader");
                 let db = db.clone();
 
                 move || {
-                    use std::ops::Bound::{Excluded, Included};
-
-                    let mut last_key;
-
+                    let mut last_key = 0u128;
                     loop {
-                        if let Some((key, _)) = db.first() {
-                            db.remove_unique(&key, fsync);
-                            last_key = Some(key);
-                            break;
-                        }
-                    }
-
-                    for _ in 0.. {
-                        let mut key_bytes = [0; 16];
-                        key_bytes.copy_from_slice(last_key.as_deref().unwrap());
-
-                        // NOTE: Make the range very tight
-                        let upper_key = u128::from_be_bytes(key_bytes) + 1;
-                        let upper_key: &[u8] = &upper_key.to_be_bytes();
-
-                        let range = (Excluded(last_key.as_deref().unwrap()), Included(upper_key));
-
-                        if let Some((key, _)) = db.range_first(range) {
-                            db.remove_unique(&key, fsync);
-                            last_key = Some(key);
+                        let last_key_bytes = last_key.to_be_bytes();
+                        let start_exclusive = std::ops::Bound::Excluded(&last_key_bytes[..]);
+                        if let Some((key, _)) =
+                            db.range_first((start_exclusive, std::ops::Bound::Unbounded))
+                        {
+                            last_key = u128::from_be_bytes(key[..].try_into().unwrap());
+                            db.remove_unique(&key, fsync, decrement_workload_size);
+                            if pending_writes.fetch_sub(1, Ordering::Relaxed) >= max_pending
+                                && with_backpressure
+                            {
+                                // Notify the writer that we consumed one
+                                condvar.notify_one();
+                            }
+                        } else {
+                            // Wait for the writer to write one
+                            let _guard = condvar.wait(mutex.lock().unwrap()).unwrap();
                         }
                     }
                 }
@@ -315,7 +345,7 @@ pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<A
                     for x in 0u128.. {
                         let key = x.to_be_bytes();
                         rng.fill_bytes(&mut buf);
-                        db.insert(&key, &key, fsync);
+                        db.insert(&key, &key, fsync, true);
                     }
                 }
             });
@@ -332,73 +362,77 @@ pub fn run_workload(db: DatabaseWrapper, args: &RunOptions, finish_signal: Arc<A
                     let mut buf = vec![0; value_size];
                     let mut rng = rand::thread_rng();
 
-                    for x in 0u128.. {
-                        let mut hash = std::hash::DefaultHasher::default();
-                        hash.write_u128(x);
-                        let key = hash.finish().to_be_bytes();
-
+                    for x in 0u64.. {
+                        let key = (hash_key(x) as u128).to_be_bytes();
                         rng.fill_bytes(&mut buf);
-
-                        db.insert(&key, &buf, fsync);
+                        db.insert(&key, &buf, fsync, true);
                     }
                 }
             });
 
             start_killer(args.seconds, finish_signal);
         }
-        Workload::Random => {
-            let value_size = args.value_size as usize;
-            let mut buf = vec![0; value_size];
-
-            {
-                for i in 0..args.item_count {
-                    let key = &{
-                        let mut hash = std::hash::DefaultHasher::default();
-                        hash.write_usize(i);
-                        hash.finish().to_be_bytes()
-                    };
-
-                    db.insert(key, &buf, fsync)
-                }
-            }
-
-            std::thread::spawn({
-                log::debug!("Starting writer");
-                let db = db.clone();
-
-                move || {
-                    let mut rng = rand::thread_rng();
-
-                    for x in 0u128.. {
-                        let mut hash = std::hash::DefaultHasher::default();
-                        hash.write_u128(x);
-                        let key = hash.finish().to_be_bytes();
-
-                        rng.fill_bytes(&mut buf);
-
-                        db.insert(&key, &buf, fsync);
-                    }
-                }
-            });
-
-            std::thread::spawn({
-                log::debug!("Starting reader");
-                let db = db.clone();
-                let mut i = args.item_count;
-
-                move || loop {
-                    let key = &{
-                        let mut hash = std::hash::DefaultHasher::default();
-                        hash.write_usize(i);
-                        hash.finish().to_be_bytes()
-                    };
-                    i += 1;
-
-                    db.get(key);
-                }
-            });
-
-            start_killer(args.seconds, finish_signal);
+        Workload::ReadWriteIndependent => {
+            read_write::run_independent(args, &db, finish_signal);
+        }
+        Workload::ReadWrite => {
+            read_write::run(args, &db, finish_signal);
         }
     };
+}
+
+/// Hash a key using the default hasher.
+/// This is used to make incremental keys look random.
+pub fn hash_key(key: impl std::hash::Hash) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Choose a key using a zipfian distribution biased towards the
+/// end of the range.
+/// The key is chosen from the range [0, written_count), except for
+/// the case when written_count is 0, in which case 0 is returned.
+pub fn choose_zipf(rng: &mut impl Rng, exponent: f64, written_count: u64) -> u64 {
+    if written_count == 0 {
+        return 0;
+    }
+    written_count
+        - ZipfDistribution::new(written_count as usize, exponent)
+            .unwrap()
+            .sample(rng) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::thread_rng;
+
+    #[test]
+    fn test_zipf_1_based() {
+        let mut rng = thread_rng();
+        let exponent = 1.0;
+        let zipf = ZipfDistribution::new(1, exponent).unwrap();
+        for _ in 0..10000 {
+            let x = zipf.sample(&mut rng);
+            assert_eq!(x, 1);
+        }
+    }
+
+    #[test]
+    fn test_choose_zipf() {
+        let mut rng = thread_rng();
+        for exponent in [0.001, 0.1, 1.0, 2.0, 3.0] {
+            for written_count in [0, 1, 1000] {
+                for _ in 0..10000 {
+                    let x = choose_zipf(&mut rng, exponent, written_count);
+                    if written_count == 0 {
+                        assert_eq!(x, 0);
+                    } else {
+                        assert!(x < written_count);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/workload/monotonic.rs
+++ b/src/workload/monotonic.rs
@@ -1,10 +1,10 @@
 use super::start_killer;
 use crate::args::RunOptions;
 use crate::db::DatabaseWrapper;
+use crate::workload::choose_zipf;
 use rand::{Rng, RngCore};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use zipf::ZipfDistribution;
 
 pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBool>) {
     let fsync = args.fsync;
@@ -36,8 +36,7 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
             for x in (item_count as u128).. {
                 let key = x.to_be_bytes();
                 rng.fill_bytes(&mut buf);
-                db.insert(&key, &buf, fsync);
-
+                db.insert(&key, &buf, fsync, true);
                 written_count.fetch_add(1, Ordering::Relaxed);
             }
         }
@@ -47,26 +46,21 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
         log::debug!("Starting reader");
         let db = db.clone();
         let written_count = written_count.clone();
-        let random = args.random;
+        let random = args.read_random;
+        let exponent = args.zipf_exponent;
 
         move || {
             let mut rng = rand::thread_rng();
-
             loop {
-                let item_count = written_count.load(Ordering::Relaxed) as u128;
-
-                if item_count > 1 {
-                    use rand::prelude::Distribution;
-
-                    let x: u128 = if random {
-                        rng.gen_range(0..item_count)
+                let written_count = written_count.load(Ordering::Relaxed);
+                if written_count > 1 {
+                    let x = if random {
+                        rng.gen_range(0..written_count)
                     } else {
-                        let zipf = ZipfDistribution::new((item_count as usize) - 1, 1.0).unwrap();
-
-                        zipf.sample(&mut rng) as u128
+                        choose_zipf(&mut rng, exponent, written_count)
                     };
 
-                    db.get(&x.to_be_bytes()).unwrap();
+                    db.get(&(x as u128).to_be_bytes()).unwrap();
                 }
             }
         }

--- a/src/workload/monotonic_fixed.rs
+++ b/src/workload/monotonic_fixed.rs
@@ -1,27 +1,28 @@
 use super::start_killer;
 use crate::args::RunOptions;
 use crate::db::DatabaseWrapper;
-use rand::prelude::Distribution;
+use crate::workload::choose_zipf;
 use rand::{Rng, RngCore};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use zipf::ZipfDistribution;
 
 pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBool>) {
     log::debug!("Ingesting data");
-    let item_count = args.item_count as u128;
+    let item_count = args.item_count as u64;
 
     let mut buf = vec![0; args.value_size as usize];
     let mut rng = rand::thread_rng();
 
     let iter = (0..item_count).map(|x| {
         rng.fill_bytes(&mut buf);
-        (x.to_be_bytes().to_vec(), buf.to_vec())
+        ((x as u128).to_be_bytes().to_vec(), buf.to_vec())
     });
 
     db.ingest(iter);
 
     if args.warmup_cache {
+        // TODO: this should probably be a separate function
+        // as length might perform no warn-up at all
         log::debug!("Warming up cache");
         assert_eq!(db.len(), args.item_count);
     }
@@ -29,19 +30,19 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
     std::thread::spawn({
         log::debug!("Starting reader");
         let db = db.clone();
-        let random = args.random;
+        let random = args.read_random;
+        let exponent = args.zipf_exponent;
 
         move || {
             let mut rng = rand::thread_rng();
-            let dist = ZipfDistribution::new((item_count as usize) - 1, 1.0).unwrap();
 
             loop {
                 let x = if random {
                     rng.gen_range(0..item_count)
                 } else {
-                    dist.sample(&mut rng) as u128
+                    choose_zipf(&mut rng, exponent, item_count)
                 };
-                db.get(&x.to_be_bytes()).unwrap();
+                db.get(&(x as u128).to_be_bytes()).unwrap();
             }
         }
     });

--- a/src/workload/read_write.rs
+++ b/src/workload/read_write.rs
@@ -1,0 +1,168 @@
+use super::{hash_key, start_killer};
+use crate::args::RunOptions;
+use crate::db::DatabaseWrapper;
+use crate::workload::choose_zipf;
+use rand::{Rng, RngCore};
+use std::{
+    collections::BTreeSet,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
+
+pub(crate) fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBool>) {
+    let item_count = args.item_count as u64;
+    let value_size = args.value_size as usize;
+    let exponent = args.zipf_exponent;
+    let fsync = args.fsync;
+    let random_key_distribution = args.write_random;
+    let read_random = args.read_random;
+    let key_mapper = move |k: u64| -> u64 {
+        if random_key_distribution {
+            k
+        } else {
+            hash_key(k)
+        }
+    };
+
+    {
+        let mut rng = rand::thread_rng();
+        let mut buf = vec![0; value_size];
+        for i in 0..item_count {
+            let key = &key_mapper(i).to_be_bytes();
+            rng.fill_bytes(&mut buf);
+
+            db.insert(key, &buf, fsync, true);
+        }
+    }
+
+    let written_count = Arc::new(AtomicU64::new(item_count));
+    let disjoint = Arc::new(Mutex::new(BTreeSet::new()));
+    let next_write = Arc::new(AtomicU64::new(item_count));
+    for _ in 0..args.threads {
+        std::thread::spawn({
+            log::debug!("Starting writer");
+            let mut buf = vec![0; value_size];
+            let db = db.clone();
+            let written_count = written_count.clone();
+            let next_write = next_write.clone();
+            let disjoint = disjoint.clone();
+
+            move || {
+                let mut rng = rand::thread_rng();
+                loop {
+                    if rng.gen_bool(0.5) {
+                        let x = next_write.fetch_add(1, Ordering::SeqCst);
+                        let key = &key_mapper(x).to_be_bytes();
+                        rng.fill_bytes(&mut buf);
+                        db.insert(key, &buf, fsync, true);
+                        if let Err(count) = written_count.compare_exchange(
+                            x,
+                            x + 1,
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                        ) {
+                            let mut updated_count = count;
+                            let mut disjoint = disjoint.lock().unwrap();
+                            disjoint.insert(x + 1);
+                            while let Some(&next) = disjoint.first() {
+                                if next == updated_count + 1 {
+                                    updated_count = next;
+                                    disjoint.pop_first();
+                                } else {
+                                    break;
+                                }
+                            }
+                            drop(disjoint);
+                            if updated_count != count {
+                                written_count.store(updated_count, Ordering::Release);
+                            }
+                        }
+                    } else {
+                        let written_count = written_count.load(Ordering::Acquire);
+                        let x = if read_random {
+                            rng.gen_range(0..written_count)
+                        } else {
+                            choose_zipf(&mut rng, exponent, written_count)
+                        };
+                        let key = &key_mapper(x).to_be_bytes();
+                        db.get(key);
+                    }
+                }
+            }
+        });
+    }
+
+    start_killer(args.seconds, finish_signal);
+}
+
+pub(crate) fn run_independent(
+    args: &RunOptions,
+    db: &DatabaseWrapper,
+    finish_signal: Arc<AtomicBool>,
+) {
+    let fsync = args.fsync;
+    let item_count = args.item_count as u64;
+    let value_size = args.value_size as usize;
+    let random_key_distribution = args.write_random;
+    let read_random = args.read_random;
+    let exponent = args.zipf_exponent;
+    let key_mapper = move |k: u64| -> u64 {
+        if random_key_distribution {
+            k
+        } else {
+            hash_key(k)
+        }
+    };
+
+    {
+        let mut rng = rand::thread_rng();
+        let mut buf = vec![0; value_size];
+        for i in 0..item_count {
+            let key = &key_mapper(i).to_be_bytes();
+            rng.fill_bytes(&mut buf);
+            db.insert(key, &buf, fsync, true);
+        }
+    }
+
+    let written_count = Arc::new(AtomicU64::new(item_count));
+    std::thread::spawn({
+        log::debug!("Starting writer");
+        let db = db.clone();
+        let written_count = written_count.clone();
+
+        move || {
+            let mut rng = rand::thread_rng();
+            let mut buf = vec![0; value_size];
+
+            for x in item_count.. {
+                let key = &key_mapper(x).to_be_bytes();
+                rng.fill_bytes(&mut buf);
+                db.insert(key, &buf, fsync, true);
+                written_count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    });
+
+    std::thread::spawn({
+        log::debug!("Starting reader");
+        let db = db.clone();
+
+        move || {
+            let mut rng = rand::thread_rng();
+            loop {
+                let written_count = written_count.load(Ordering::Relaxed);
+                let x = if read_random {
+                    rng.gen_range(0..written_count)
+                } else {
+                    choose_zipf(&mut rng, exponent, written_count)
+                };
+                let key = &key_mapper(x).to_be_bytes();
+                db.get(key);
+            }
+        }
+    });
+
+    start_killer(args.seconds, finish_signal);
+}

--- a/src/workload/ycsb/a.rs
+++ b/src/workload/ycsb/a.rs
@@ -8,6 +8,7 @@ use zipf::ZipfDistribution;
 
 pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBool>) {
     let fsync = args.fsync;
+    let exponent = args.zipf_exponent;
     let item_count = args.item_count as u64;
 
     assert!(item_count > 0);
@@ -28,13 +29,14 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
     let worker = std::thread::spawn({
         log::debug!("Starting reader");
         let db = db.clone();
-        let random = args.random;
+        let random = args.read_random;
         let mut buf = vec![0; args.value_size as usize];
 
         move || {
             use rand::prelude::Distribution;
 
             let mut rng = rand::thread_rng();
+            let zipf = ZipfDistribution::new(item_count as usize, exponent).unwrap();
 
             loop {
                 match rng.gen_range(0.0..1.0) {
@@ -42,10 +44,7 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
                         let x: u128 = if random {
                             rng.gen_range(0..item_count as u128)
                         } else {
-                            let zipf =
-                                ZipfDistribution::new((item_count as usize) - 1, 1.0).unwrap();
-
-                            zipf.sample(&mut rng) as u128
+                            (zipf.sample(&mut rng) - 1) as u128
                         };
 
                         db.get(&x.to_be_bytes()).unwrap();
@@ -54,14 +53,11 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
                         let x: u128 = if random {
                             rng.gen_range(0..item_count as u128)
                         } else {
-                            let zipf =
-                                ZipfDistribution::new((item_count as usize) - 1, 1.0).unwrap();
-
-                            zipf.sample(&mut rng) as u128
+                            (zipf.sample(&mut rng) - 1) as u128
                         };
 
                         rng.fill_bytes(&mut buf);
-                        db.insert(&x.to_be_bytes(), &buf, fsync);
+                        db.insert(&x.to_be_bytes(), &buf, fsync, false);
                     }
                 }
             }

--- a/src/workload/ycsb/b.rs
+++ b/src/workload/ycsb/b.rs
@@ -28,13 +28,15 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
     let worker = std::thread::spawn({
         log::debug!("Starting reader");
         let db = db.clone();
-        let random = args.random;
+        let random = args.read_random;
+        let exponent = args.zipf_exponent;
         let mut buf = vec![0; args.value_size as usize];
 
         move || {
             use rand::prelude::Distribution;
 
             let mut rng = rand::thread_rng();
+            let zipf = ZipfDistribution::new(item_count as usize, exponent).unwrap();
 
             loop {
                 match rng.gen_range(0.0..1.0) {
@@ -42,10 +44,7 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
                         let x: u128 = if random {
                             rng.gen_range(0..item_count as u128)
                         } else {
-                            let zipf =
-                                ZipfDistribution::new((item_count as usize) - 1, 1.0).unwrap();
-
-                            zipf.sample(&mut rng) as u128
+                            (zipf.sample(&mut rng) - 1) as u128
                         };
 
                         db.get(&x.to_be_bytes()).unwrap();
@@ -54,14 +53,11 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
                         let x: u128 = if random {
                             rng.gen_range(0..item_count as u128)
                         } else {
-                            let zipf =
-                                ZipfDistribution::new((item_count as usize) - 1, 1.0).unwrap();
-
-                            zipf.sample(&mut rng) as u128
+                            (zipf.sample(&mut rng) - 1) as u128
                         };
 
                         rng.fill_bytes(&mut buf);
-                        db.insert(&x.to_be_bytes(), &buf, fsync);
+                        db.insert(&x.to_be_bytes(), &buf, fsync, false);
                     }
                 }
             }

--- a/src/workload/ycsb/c.rs
+++ b/src/workload/ycsb/c.rs
@@ -29,20 +29,20 @@ pub fn run(args: &RunOptions, db: &DatabaseWrapper, finish_signal: Arc<AtomicBoo
         .spawn({
             log::debug!("Starting reader");
             let db = db.clone();
-            let random = args.random;
+            let random = args.read_random;
+            let exponent = args.zipf_exponent;
 
             move || {
                 use rand::prelude::Distribution;
 
                 let mut rng = rand::thread_rng();
+                let zipf = ZipfDistribution::new(item_count as usize, exponent).unwrap();
 
                 loop {
                     let x: u128 = if random {
                         rng.gen_range(0..item_count as u128)
                     } else {
-                        let zipf = ZipfDistribution::new((item_count as usize) - 1, 1.0).unwrap();
-
-                        zipf.sample(&mut rng) as u128
+                        (zipf.sample(&mut rng) - 1) as u128
                     };
 
                     db.get(&x.to_be_bytes()).unwrap();

--- a/write.nu
+++ b/write.nu
@@ -3,7 +3,7 @@
 let prefix = "randomwrite";
 let data_dir = ".data";
 let seconds = 10 * 60;
-let cache_mib = 1_000 * 1_024 * 1_024;
+let cache = 1_000 * 1_024 * 1_024;
 let value_size = 96;
 
 alias bench = cargo run -r --
@@ -11,7 +11,7 @@ alias bench = cargo run -r --
 for db in ["rocksdb", "heed", "fjall"] {
     let out = $"($prefix)_($db).jsonl";
     print $out;
-    RUST_BACKTRACE=full RUST_LOG=warn bench run --seconds $seconds --out $out --workload random-write --value-size $value_size --backend $db --data-dir $data_dir --item-count 100 --cache-size $cache_mib
+    RUST_BACKTRACE=full RUST_LOG=warn bench run --seconds $seconds --out $out --workload random-write --value-size $value_size --backend $db --data-dir $data_dir --item-count 100 --cache-size $cache
     sleep 500ms
 }
 


### PR DESCRIPTION
* Rename `random` workload to `read-write` as that's fully customizable with the new options
* Split `read-write` and `read-write-independent`, the first runs a configurable number of read+write threads (new), and the latter runs independent write and read threads (same as before)
* Fix out-of-order ingestion on the `feed` workload and attempt to respect the configured item count when populating the initial feed
* Added a `queue` like workload that throttles the producer to the same-ish throughput as the consumer
* Split `queue` (new, as described above) and `queue-independent` (same as before)
* `timeseries` workload changed to range scan 1_000 entries from the end
* New implementations and fixes for the database wrapper functions
* Fixed broken reporting due to wrong slice in `report/src/data.ts`
* Remove some special-case range functions that became unused
* When issuing Zipf reads to a growing workload, bias to the end/newest side of the range instead of the low/oldest. This should be more representative of a real workload.
* Fix off-by-1 errors when sampling from zipfian distribution (which yields 1..=N)
* Update histogram crate to DD-Sketch and remove deci-nano-seconds conversions
* Add `zipf-exponent` option
* Add `threads` option
* Add `write-random` option
* Rename `random` option to `read-random`
* Augment statistics to allow tracking the real size of the workload (supports space amp. calculation)
* Add space amplification calculation

